### PR TITLE
Race condition in ParallelForEachAsync when exceptions are thrown

### DIFF
--- a/src/Extensions/ParallelForEachExtensions.cs
+++ b/src/Extensions/ParallelForEachExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -78,7 +79,7 @@ namespace Dasync.Collections
                 {
                     // Return a copy, so the list being returned will not be modified
                     // by tasks that are still running if the loop was canceled
-                    return new List<Exception>(_exceptionList);
+                    return new List<Exception>(_exceptionList ?? Enumerable.Empty<Exception>());
                 }
                 finally
                 {

--- a/src/Extensions/ParallelForEachExtensions.cs
+++ b/src/Extensions/ParallelForEachExtensions.cs
@@ -76,11 +76,12 @@ namespace Dasync.Collections
                     _exceptionListLock.Enter(ref lockTaken);
                 try
                 {
-                    return _exceptionList;
+                    // Return a copy, so the list being returned will not be modified
+                    // by tasks that are still running if the loop was canceled
+                    return new List<Exception>(_exceptionList);
                 }
                 finally
                 {
-                    _exceptionList = null;
                     _exceptionListLock.Exit(useMemoryBarrier: false);
                 }
             }


### PR DESCRIPTION
Not resetting exception list to null in ReadExceptions, so that in case multiple tasks are finishing at the same time they will all read a non-empty list of exceptions.

Returning a copy of exception list from ReadExceptions to prevent concurrent reads by CompleteLoopNow and writes by tasks still running in case the loop was canceled.